### PR TITLE
Remove dirname from vite reload path(s)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -29,7 +29,7 @@ export default defineConfig(({command}) => ({
     }),
     ViteRestart({
       reload: [
-        path.resolve(__dirname, 'templates/**/*'),
+        'templates/**/*',
       ],
     }),
   ],


### PR DESCRIPTION
Had trouble getting Vite to reload on template changes, and noticed that [vite-plugin-restart](https://github.com/antfu/vite-plugin-restart/blob/d5fab1c4589de1ebaac25cbc8163642d268a7fcb/src/index.ts#L93) adds the project's Vite config root path to all specified reload paths:

    reloadGlobs = toArray(options.reload).map(i => path.posix.join(root, i))

So with __dirname in the reload paths you're adding prepending the root path again...

    ViteRestart({
      reload: [
        path.resolve(__dirname, 'templates/**/*'), // /var/www/html/var/www/html/templates/**/*
      ],
    }),